### PR TITLE
fix(scanner): handle comments containing percentages

### DIFF
--- a/wau-scanner.lua
+++ b/wau-scanner.lua
@@ -179,7 +179,7 @@ function printer.comment(s)
     if printer.include_comments then
         local toprint = s:gsub("^%s*", "-- "):gsub("\n%s*", "\n-- ")
         for line in (toprint ..'\n'):gmatch'(.-)\r?\n' do
-            printer.line(line)
+            printer.line("%s", line)
         end
     end
     return printer


### PR DESCRIPTION
The first parameter to `printer.line` is a format string, so pass in explicit `"%s"` to print the line verbatim. Caught this with single-pixel-buffer-v1.xml, which mentions "0% of the given color component" and "100% of the given color component" in a comment.